### PR TITLE
A better way to determine which constructor of ERB.new to use.

### DIFF
--- a/lib/pechkin/message_template.rb
+++ b/lib/pechkin/message_template.rb
@@ -8,31 +8,11 @@ module Pechkin
 
   # Message template to render final message.
   class MessageTemplate
-    class << self
-      def ruby_v260_or_later?(ruby_version = RUBY_VERSION)
-        # Need to compare two versions, one is 2.6.0 - which supports keyword
-        # arguments in ERB#initialize. Everything below that should use legacy
-        # arguments
-        rb_v260 = [2, 6, 0]
-        rb_current = ruby_version.split('.').map(&:to_i)
-
-        rb_v260.zip(rb_current).each do |x, y|
-          x ||= 0
-          y ||= 0
-          return false if y < x
-        end
-
-        true
-      end
-    end
-
-    RUBY_V260 = MessageTemplate.ruby_v260_or_later?
-
     def initialize(erb)
       # ERB#initialize has different signature starting from Ruby 2.6.*
       # See link:
       # https://github.com/ruby/ruby/blob/2311087/NEWS#stdlib-updates-outstanding-ones-only
-      if MessageTemplate::RUBY_V260
+      if ERB.instance_method(:initialize).parameters.assoc(:key) # Ruby 2.6+
         @erb_template = ERB.new(erb, trim_mode: '-')
       else
         safe_level = nil

--- a/lib/pechkin/message_template.rb
+++ b/lib/pechkin/message_template.rb
@@ -6,13 +6,15 @@ module Pechkin
     end
   end
 
+  ERB_INITIALIZE_KEYWORD_ARGUMENTS = ERB.instance_method(:initialize).parameters.assoc(:key)
+
   # Message template to render final message.
   class MessageTemplate
     def initialize(erb)
       # ERB#initialize has different signature starting from Ruby 2.6.*
       # See link:
       # https://github.com/ruby/ruby/blob/2311087/NEWS#stdlib-updates-outstanding-ones-only
-      if ERB.instance_method(:initialize).parameters.assoc(:key) # Ruby 2.6+
+      if ERB_INITIALIZE_KEYWORD_ARGUMENTS # Ruby 2.6+
         @erb_template = ERB.new(erb, trim_mode: '-')
       else
         safe_level = nil

--- a/lib/pechkin/message_template.rb
+++ b/lib/pechkin/message_template.rb
@@ -6,15 +6,16 @@ module Pechkin
     end
   end
 
-  ERB_INITIALIZE_KEYWORD_ARGUMENTS = ERB.instance_method(:initialize).parameters.assoc(:key)
-
   # Message template to render final message.
   class MessageTemplate
+
+    ERB_INITIALIZE_KEYWORD_ARGUMENTS = ERB.instance_method(:initialize).parameters.assoc(:key)
+
     def initialize(erb)
       # ERB#initialize has different signature starting from Ruby 2.6.*
       # See link:
       # https://github.com/ruby/ruby/blob/2311087/NEWS#stdlib-updates-outstanding-ones-only
-      if ERB_INITIALIZE_KEYWORD_ARGUMENTS # Ruby 2.6+
+      if MessageTemplate::ERB_INITIALIZE_KEYWORD_ARGUMENTS # Ruby 2.6+
         @erb_template = ERB.new(erb, trim_mode: '-')
       else
         safe_level = nil

--- a/spec/pechkin/message_template_spec.rb
+++ b/spec/pechkin/message_template_spec.rb
@@ -10,14 +10,6 @@ module Pechkin
       expect(MessageTemplate.new(template).render({}))
         .to eq("Hello\n")
     end
-
-    describe '::ruby_v260_or_later?' do
-      it { expect(MessageTemplate.ruby_v260_or_later?('2.7')).to be(true) }
-      it { expect(MessageTemplate.ruby_v260_or_later?('2.6.1')).to be(true) }
-      it { expect(MessageTemplate.ruby_v260_or_later?('2.6.0')).to be(true) }
-      it { expect(MessageTemplate.ruby_v260_or_later?('2.5.1')).to be(false) }
-      it { expect(MessageTemplate.ruby_v260_or_later?('1.9')).to be(false) }
-    end
   end
 
   describe MessageBinding do


### PR DESCRIPTION
ERB#initialize has different signature starting from Ruby 2.6.*
See link:
  https://github.com/ruby/ruby/blob/2311087/NEWS#stdlib-updates-outstanding-ones-only
