### PR TITLE
chore(build): support ruby >=3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,8 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - 2.6
           - 3.0
+          - 3.3
     steps:
       - uses: actions/checkout@v1
       - name: Setup ruby

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: Lint & Tests
 on:
   - push
+  - pull_request_target
 jobs:
   lint:
     name: Lint & Test

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 3.0
 
 Metrics/ModuleLength:
   Exclude:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.6
 
 Metrics/ModuleLength:
   Exclude:

--- a/lib/pechkin/app/request_handler.rb
+++ b/lib/pechkin/app/request_handler.rb
@@ -2,7 +2,7 @@ module Pechkin
   # Http requests handler. We need fresh instance per each request. To keep
   # internal state isolated
   class RequestHandler
-    REQ_PATH_PATTERN = %r{^/(.+)/([^/]+)/?$}.freeze
+    REQ_PATH_PATTERN = %r{^/(.+)/([^/]+)/?$}
 
     attr_reader :req, :handler,
                 :channel_id, :message_id,

--- a/lib/pechkin/command/send_data.rb
+++ b/lib/pechkin/command/send_data.rb
@@ -27,7 +27,7 @@ module Pechkin
 
       def read_data(data)
         d = if data.start_with?('@')
-              file = data[1..-1]
+              file = data[1..]
               raise "File not found #{file}" unless File.exist?(file)
 
               IO.read(file)

--- a/lib/pechkin/configuration/configuration_loader_views.rb
+++ b/lib/pechkin/configuration/configuration_loader_views.rb
@@ -18,7 +18,7 @@ module Pechkin
       raise ConfigurationError, "'#{views_dir}' is not a directory" unless File.directory?(views_dir)
 
       Dir["#{views_dir}/**/*.erb"].each do |f|
-        relative_path = f["#{views_dir}/".length..-1]
+        relative_path = f["#{views_dir}/".length..]
         views[relative_path] = MessageTemplate.new(IO.read(f))
       end
     end

--- a/lib/pechkin/message_template.rb
+++ b/lib/pechkin/message_template.rb
@@ -18,9 +18,8 @@ module Pechkin
       if MessageTemplate::ERB_INITIALIZE_KEYWORD_ARGUMENTS # Ruby 2.6+
         @erb_template = ERB.new(erb, trim_mode: '-')
       else
-        safe_level = nil
         trim_mode = '-'
-        @erb_template = ERB.new(erb, safe_level, trim_mode)
+        @erb_template = ERB.new(erb, trim_mode: trim_mode)
       end
     end
 

--- a/pechkin.gemspec
+++ b/pechkin.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.executables << 'pechkin'
   s.homepage = 'https://github.com/iarkhanhelsky/pechkin'
 
-  s.required_ruby_version = '> 2.6'
+  s.required_ruby_version = '>= 2.6'
 
   s.add_runtime_dependency 'htauth', '2.2.0'
   s.add_runtime_dependency 'powerpack', '0.1.3'

--- a/pechkin.gemspec
+++ b/pechkin.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.executables << 'pechkin'
   s.homepage = 'https://github.com/iarkhanhelsky/pechkin'
 
-  s.required_ruby_version = '> 3.0'
+  s.required_ruby_version = '> 2.6'
 
   s.add_runtime_dependency 'htauth', '2.2.0'
   s.add_runtime_dependency 'powerpack', '0.1.3'

--- a/pechkin.gemspec
+++ b/pechkin.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.executables << 'pechkin'
   s.homepage = 'https://github.com/iarkhanhelsky/pechkin'
 
-  s.required_ruby_version = '>= 2.6'
+  s.required_ruby_version = '>= 3.0'
 
   s.add_runtime_dependency 'htauth', '2.2.0'
   s.add_runtime_dependency 'powerpack', '0.1.3'


### PR DESCRIPTION
Add support for ruby >=3.0. 
Support for 2.x has been dropped as these versions reached EOL. 
Updated github actions to run CI checks on pull reuqests 