### PR TITLE
Deleted multiple workers configuration

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    pechkin (1.6.0)
+    pechkin (2.0.0)
       htauth (= 2.2.0)
       powerpack (= 0.1.3)
       prometheus-client (= 4.2.2)

--- a/lib/pechkin/cli.rb
+++ b/lib/pechkin/cli.rb
@@ -102,9 +102,6 @@ module Pechkin
     opt :pid_file, names: ['-p', '--pid-file [FILE]'],
                    desc: 'Path to output PID file'
 
-    opt :server_workers, names: ['--min-threads [SERVER_WORKERS]'], default: 2, type: Integer,
-                         desc: 'Server workers count. Default: 1'
-
     opt :min_threads, names: ['--min-threads [MIN_THREADS]'], default: 5, type: Integer,
                       desc: 'Min threads count. Default: 5'
 

--- a/lib/pechkin/command/run_server.rb
+++ b/lib/pechkin/command/run_server.rb
@@ -12,7 +12,6 @@ module Pechkin
         # Configure Puma server instead config.ru
         puma_config = Puma::Configuration.new do |user_config|
           user_config.bind "tcp://#{options.bind_address}:#{options.port}"
-          user_config.workers options.server_workers # Set number of workers
           user_config.threads options.min_threads, options.max_threads # Set max and min threads
           user_config.app AppBuilder.new.build(handler, options)
         end


### PR DESCRIPTION
When using a configuration with multiple workers, it's necessary to implement metric sharing among the workers. Otherwise, metric collection for different requests will alternate between the workers.